### PR TITLE
Fix eng modifiers

### DIFF
--- a/modifiers-eng.ts
+++ b/modifiers-eng.ts
@@ -36,6 +36,9 @@ export const capitalize = (text: string): string =>
 /** Converts all characters to lowercase. */
 export const lowercase = (s: string): string => s.toLowerCase();
 
+/** Converts all characters to uppercase. */
+export const uppercase = (s: string): string => s.toUpperCase();
+
 /**
  * Adds prefix 'a' or 'an' depending on the text. If text begins with u
  * followed by i (e.g. unicorn), 'a' prefix is used. Otherwise if text begins
@@ -124,6 +127,7 @@ export const modifiers = Object.freeze({
   capitalizeAll,
   capitalize,
   lowercase,
+  uppercase,
   a,
   s,
   firstS,


### PR DESCRIPTION
We were previously relying on the exported functions, but importing `*` would not work as a modifier dict, because the `isX` functions aren't modifiers.